### PR TITLE
[yamui] Add universal power key handler. Contributes to JB#32244

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 RPMS
 yamui
+yamui-powerkey
 yamui-screensaverd
 documentation.list

--- a/Makefile
+++ b/Makefile
@@ -2,26 +2,37 @@ PROGRAM = yamui
 C_FILES := main.c os-update.c minui/graphics.c minui/graphics_fbdev.c minui/events.c minui/resources.c
 OBJS := $(patsubst %.c, %.o, $(C_FILES))
 CC = cc
-CFLAGS = -Wall -DOVERSCAN_PERCENT=0 -I/usr/include/ -O2 -Wall
+CFLAGS = -Wall -DOVERSCAN_PERCENT=0 -I/usr/include/ -O2
 LDFLAGS = -lpng -lc -lz -lm
+
+OBJS_COMMON := yamui-tools.o
 
 SCREENSAVERD = yamui-screensaverd
 CFLAGS_SCREENSAVERD = -W -Wall -ansi -pedantic -O2
 C_FILES_SCREENSAVERD := yamui-screensaverd.c
 OBJS_SCREENSAVERD := $(patsubst %.c, %.o, $(C_FILES_SCREENSAVERD))
 
-all: $(PROGRAM) $(SCREENSAVERD)
+POWERKEY = yamui-powerkey
+CFLAGS_POWERKEY = -W -Wall -ansi -pedantic -O2
+C_FILES_POWERKEY := yamui-powerkey.c
+OBJS_POWERKEY := $(patsubst %.c, %.o, $(C_FILES_POWERKEY))
+
+all: $(PROGRAM) $(SCREENSAVERD) $(POWERKEY)
 
 $(PROGRAM): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) -o $(PROGRAM)
 
-$(SCREENSAVERD): $(OBJS_SCREENSAVERD)
-	$(CC) $(CFLAGS_SCREENSAVERD) $(OBJS_SCREENSAVERD) -o $(SCREENSAVERD)
+$(SCREENSAVERD): $(OBJS_SCREENSAVERD) $(OBJS_COMMON)
+	$(CC) $(CFLAGS_SCREENSAVERD) $(OBJS_SCREENSAVERD) $(OBJS_COMMON) -o $(SCREENSAVERD)
+
+$(POWERKEY): $(OBJS_POWERKEY) $(OBJS_COMMON)
+	$(CC) $(CFLAGS_POWERKEY) $(OBJS_POWERKEY) $(OBJS_COMMON) -o $(POWERKEY)
 
 install: all
 	strip $(PROGRAM) $(SCREENSAVERD)
 	install -m 755 -D $(PROGRAM) $(DESTDIR)/usr/bin/$(PROGRAM)
 	install -m 755 -D $(SCREENSAVERD) $(DESTDIR)/usr/bin/$(SCREENSAVERD)
+	install -m 755 -D $(POWERKEY) $(DESTDIR)/usr/bin/$(POWERKEY)
 
 clean:
 	rm -f *.o minui/*.o

--- a/rpm/yamui.spec
+++ b/rpm/yamui.spec
@@ -25,4 +25,5 @@ make
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
+%{_bindir}/yamui-powerkey
 %{_bindir}/yamui-screensaverd

--- a/yamui-powerkey.c
+++ b/yamui-powerkey.c
@@ -1,0 +1,312 @@
+/*
+ * Power key handler. Waits for all event devices providing KEY_POWER events.
+ * Exits on power key pressed for desired time or after receiving of SIGTERM.
+ * Returns:
+ *   0 - Power key was pressed,
+ *   1 - signal was received,
+ *   2 - error.
+ *
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Igor Zhbanov <igor.zhbanov@jolla.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _BSD_SOURCE
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <linux/input.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/select.h>
+
+/*#define DEBUG*/
+#include "yamui-tools.h"
+
+#define NBITS(x)		((((x) - 1) / __BITS_PER_LONG) + 1)
+#define BIT(arr, bit)		((arr[(bit) / __BITS_PER_LONG] >> \
+				 ((bit) % __BITS_PER_LONG)) & 1)
+
+#define MAX_DEVICES		256
+#define DEFAULT_DURATION	3 /* seconds */
+
+/* EXIT_SUCCESS and EXIT_FAILURE are defined in <stdlib.h>. */
+#define EXIT_SIGNAL		2
+
+const char *app_name = "powerkey";
+sig_atomic_t volatile running = 1;
+
+/* ------------------------------------------------------------------------ */
+
+/* Check for input device type. Returns 0 if button or touchscreen. */
+static int
+check_device_type(int fd, const char *name)
+{
+	unsigned long bits[EV_MAX][NBITS(KEY_MAX)];
+
+	memset(bits, '\0', sizeof(bits));
+	if (ioctl(fd, EVIOCGBIT(0, EV_MAX), bits[0]) == -1) {
+		errorf("ioctl(, EVIOCGBIT(0, ), ) error on event device %s",
+		       name);
+		return -1;
+	}
+
+	if (BIT(bits[0], EV_KEY)) {
+		if (ioctl(fd, EVIOCGBIT(EV_KEY, KEY_MAX), bits[EV_KEY]) == -1)
+			errorf("ioctl(, EVIOCGBIT(EV_KEY, ), ) error on event"
+			       " device %s", name);
+		else if (BIT(bits[EV_KEY], KEY_POWER)) {
+			debugf("Device %s supports needed key events.", name);
+			return 0;
+		}
+	}
+
+	debugf("Skipping unsupported device %s.", name);
+	return -1;
+}
+
+/* ------------------------------------------------------------------------ */
+
+static int duration = DEFAULT_DURATION;
+static struct timeval key_tv;
+
+typedef enum {
+	key_up,
+	key_down,
+	key_long_press
+} key_state_t;
+
+static key_state_t power_key_state = key_up;
+
+static struct timeval *
+get_timeout_value(void)
+{
+	if (power_key_state ==  key_down)
+		return &key_tv;
+	else /* key_up or key_long_press */
+		return NULL; /* Wait forever */
+}
+
+/* ------------------------------------------------------------------------ */
+
+static void
+set_timeout_value(int sec)
+{
+	key_tv.tv_sec  = sec;
+	key_tv.tv_usec = 0;
+}
+
+/* ------------------------------------------------------------------------ */
+
+static void
+reset_timeout_value(void)
+{
+	key_tv.tv_sec  = duration;
+	key_tv.tv_usec = 0;
+}
+
+/* ------------------------------------------------------------------------ */
+
+typedef enum {
+	key_ev_up,
+	key_ev_down
+} key_ev_t; /* Why <linux/input.h> still doesn't define it for us? */
+
+/* Returns:
+ * ret_success	- Power key was pressed, terminate main loop.
+ * ret_continue	- Some other key was pressed or released, continue main loop.
+ */
+static ret_t
+handle_event(const struct input_event *ev)
+{
+	if (ev->type != EV_KEY || ev->code != KEY_POWER) {
+		/* We are not recalculating timeout value in case of
+		 * "interrupted" key_down state because select() properly
+		 * updates timeout value on return. This behavior of select()
+		 * is Linux-specific, and on other platforms you have to
+		 * recalculate timeout value by your own. */
+		return ret_continue; /* Ignore other events and keys */
+	}
+
+	if (power_key_state == key_up) {
+		if (ev->value == key_ev_down) {
+			debugf("New state: key_down");
+			power_key_state = key_down;
+			reset_timeout_value();
+		} /* Else key_ev_up.
+		   * This can happen with multiple Power keys.
+		   * Ignore and keep timeout unchanged. */
+	} else if (power_key_state == key_down) {
+		if (ev->value == key_ev_up) {
+			debugf("New state: key_up");
+			power_key_state = key_up;
+		} /* Else key_ev_down.
+		   * This can happen with multiple Power keys. */
+	} else { /* key_long_press */
+		if (ev->value == key_ev_up)
+			return ret_success;
+		/* Else key_ev_down.
+		 * This can happen with multiple Power keys. */
+	}
+
+	return ret_continue;
+}
+
+/* ------------------------------------------------------------------------ */
+
+bool wait_key_up = false; /* Wait for key release event. */
+
+/* Returns:
+ * ret_success	- Power key was pressed, terminate main loop.
+ * ret_continue	- Some other key was pressed or released, continue main loop.
+ * ret_failure	- Error happens, terminate the application. */
+static ret_t
+handle_timeout(void)
+{
+	if (power_key_state != key_down) { /* Should't be here. */
+		infof("Internal error: timeout in unexpected state: %d.\n",
+		      power_key_state);
+		return ret_failure;
+	}
+
+	if (!wait_key_up)
+		return ret_success;
+
+	debugf("New state: key_long_press");
+	power_key_state = key_long_press;
+	return ret_continue;
+}
+
+/* ------------------------------------------------------------------------ */
+
+static void
+signal_handler(int sig UNUSED)
+{
+	running = 0;
+}
+
+/* ------------------------------------------------------------------------ */
+
+static void
+usage(void)
+{
+	printf("Usage: yamui-%s [-d <key-press-duration>] [-u]\n", app_name);
+	printf("-d <key-press-duration>\tThe Power key press period "
+	       "in seconds before exit,\n");
+	printf("\t\t\tdefault value: %d seconds\n", DEFAULT_DURATION);
+	printf("-u\t\t\tExit on the key release event\n\n");
+	printf("Return status:\n");
+	printf("%d - Power key was pressed,\n", EXIT_SUCCESS);
+	printf("%d - error happens,\n", EXIT_FAILURE);
+	printf("%d - signal received.\n", EXIT_SIGNAL);
+}
+
+/* ------------------------------------------------------------------------ */
+
+int
+main(int argc, char *argv[])
+{
+	int opt, fds[MAX_DEVICES], num_fds = 0, ret = EXIT_SIGNAL;
+
+	while ((opt = getopt(argc, argv, "d:hu")) != -1) {
+		switch (opt) {
+			case 'd':
+				duration = atoi(optarg);
+				if ((duration = atoi(optarg)) < 1) {
+					printf("Duration value must be "
+					       "positive.\n");
+					usage();
+					return EXIT_FAILURE;
+				}
+
+				break;
+			case 'u':
+				wait_key_up = true;
+				break;
+			case 'h':
+			default:
+				usage();
+				return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc) {
+		usage();
+		return EXIT_FAILURE;
+	}
+
+	if (open_fds(fds, &num_fds, MAX_DEVICES, check_device_type) == -1)
+		return EXIT_FAILURE;
+
+	debugf("Started");
+	signal(SIGINT,  signal_handler);
+	signal(SIGTERM, signal_handler);
+	set_timeout_value(duration);
+
+	while (running) { /* Main loop */
+		int i, rv, max_fd = 0;
+		fd_set rfds;
+		struct timeval *tv;
+
+		FD_ZERO(&rfds);
+		for (i = 0; i < num_fds; i++) {
+			FD_SET(fds[i], &rfds);
+			if (fds[i] > max_fd)
+				max_fd = fds[i];
+		}
+
+		tv = get_timeout_value();
+		rv = select(max_fd + 1, &rfds, NULL, NULL, tv);
+		if (rv > 0) {
+			for (i = 0; i < num_fds; i++)
+				if (FD_ISSET(fds[i], &rfds)) {
+					ret_t r;
+
+					r = handle_events(fds[i],
+							  handle_event);
+					if (r == ret_continue)
+						continue;
+
+					ret = get_exit_status(r);
+					running = 0;
+					break;
+				}
+		} else if (rv == 0) { /* Timeout */
+			ret_t r;
+
+			if ((r = handle_timeout()) == ret_continue)
+				continue;
+
+			ret = get_exit_status(r);
+			break;
+		} else { /* Error or signal */
+			if (errno != EINTR) {
+				errorf("Error on select()");
+				ret = EXIT_FAILURE;
+			}
+
+			break;
+		}
+	}
+
+	close_fds(fds, num_fds);
+	debugf("Terminated");
+	return ret;
+}

--- a/yamui-screensaverd.c
+++ b/yamui-screensaverd.c
@@ -22,104 +22,30 @@
 #define _BSD_SOURCE
 
 #include <errno.h>
-#include <fcntl.h>
 #include <stdio.h>
-#include <dirent.h>
 #include <signal.h>
-#include <stdarg.h>
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <linux/input.h>
-#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/select.h>
+
+/*#define DEBUG*/
+#include "yamui-tools.h"
 
 #define UNUSED			__attribute__((unused))
 #define NBITS(x)		((((x) - 1) / __BITS_PER_LONG) + 1)
 #define BIT(arr, bit)		((arr[(bit) / __BITS_PER_LONG] >> \
 				 ((bit) % __BITS_PER_LONG)) & 1)
 
-/*#define DEBUG*/
-
 #define DISPLAY_CONTROL		"/sys/class/graphics/fb0/blank"
-#define DEV_INPUT_DIR		"/dev/input"
-#define LOG_NAME		"screensaverd"
-#define EVENT_PREFIX		"event"
 #define MAX_DEVICES		256
 #define DISPLAY_OFF_TIME	25 /* seconds */
-#define EVENTS_BUF_SIZE		512 /* events */
-#define EXIT_SUCCESS		0
-#define EXIT_FAILURE		1
 
+const char *app_name = "screensaverd";
 sig_atomic_t volatile running = 1;
-
-/* ------------------------------------------------------------------------ */
-
-static void
-print_common(const char *format, va_list ap)
-{
-	printf("[%s] ", LOG_NAME);
-	vprintf(format, ap);
-}
-
-/* ------------------------------------------------------------------------ */
-
-static void
-infof(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
-
-/* Info printing with printf-style format and application name prefix. */
-static void
-infof(const char *format, ...)
-{
-	va_list ap;
-	int old_errno = errno;
-
-	va_start(ap, format);
-	print_common(format, ap);
-	printf("\n");
-	va_end(ap);
-	errno = old_errno; /* Just in case. */
-}
-
-/* ------------------------------------------------------------------------ */
-
-#ifdef DEBUG
-
-#define debugf	infof
-
-#else /* !DEBUG */
-
-static void
-debugf(const char *format, ...) __attribute__ ((format (printf, 1, 2)))
-				UNUSED;
-
-static __inline__ void
-debugf(const char *format UNUSED, ...)
-{
-
-}
-
-#endif /* !DEBUG */
-
-/* ------------------------------------------------------------------------ */
-
-static void
-errorf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
-
-/* perror() with printf-style format and application name prefix. */
-static void
-errorf(const char *format, ...)
-{
-	va_list ap;
-	int old_errno = errno;
-
-	va_start(ap, format);
-	print_common(format, ap);
-	printf(": %s\n", strerror(old_errno));
-	va_end(ap);
-	errno = old_errno; /* Just in case. */
-}
 
 /* ------------------------------------------------------------------------ */
 
@@ -163,63 +89,6 @@ check_device_type(int fd, const char *name)
 
 	debugf("Skipping unsupported device %s.", name);
 	return -1;
-}
-
-/* ------------------------------------------------------------------------ */
-
-static void
-close_fds(int fds[], int num)
-{
-	int i;
-
-	for (i = 0; i < num; i++)
-		close(fds[i]);
-}
-
-/* ------------------------------------------------------------------------ */
-
-/* Open all /dev/input/event* files. */
-static int
-open_fds(int fds[], int *num, int max_num)
-{
-	DIR *dir;
-	struct dirent *d;
-
-	if (!(dir = opendir(DEV_INPUT_DIR))) {
-		errorf("Can't open directory %s", DEV_INPUT_DIR);
-		return -1;
-	}
-
-	while ((d = readdir(dir))) {
-		char name[256];
-
-		if (strncmp(d->d_name, EVENT_PREFIX, strlen(EVENT_PREFIX)))
-			continue; /* Not /dev/input/event* file */
-
-		snprintf(name, sizeof(name), "%s/%s", DEV_INPUT_DIR,
-			 d->d_name);
-		debugf("Processing input ivents file %s", name);
-		if ((fds[*num] = open(name, O_RDONLY)) == -1) {
-			errorf("Can't open input device %s", name);
-			continue;
-		}
-
-		if (check_device_type(fds[*num], name) == -1) {
-			close(fds[*num]);
-			continue;
-		}
-
-		if (++*num >= max_num)
-			break;
-	}
-
-	closedir(dir);
-	if (!*num) {
-		infof("No suitable input events devices found.");
-		return -1;
-	}
-
-	return 0;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -275,28 +144,7 @@ turn_display_off(void)
 
 /* ------------------------------------------------------------------------ */
 
-static int
-handle_events(int fd)
-{
-	int rv;
-	struct input_event buf[EVENTS_BUF_SIZE];
-
-	/* Read and ignore event data if OK. */
-	rv = read(fd, (void *)buf, sizeof(buf));
-	if (rv < 0) {
-		errorf("Error on read");
-		return -1;
-	} else if (rv == 0) {
-		infof("Unexpected EOF on read");
-		return -1;
-	}
-
-	return 0;
-}
-
-/* ------------------------------------------------------------------------ */
-
-void
+static void
 signal_handler(int sig UNUSED)
 {
 	running = 0;
@@ -309,7 +157,7 @@ main(void)
 {
 	int fds[MAX_DEVICES], num_fds = 0, ret = EXIT_SUCCESS;
 
-	if (open_fds(fds, &num_fds, MAX_DEVICES) == -1)
+	if (open_fds(fds, &num_fds, MAX_DEVICES, check_device_type) == -1)
 		return EXIT_FAILURE;
 
 	debugf("Started");
@@ -335,8 +183,14 @@ main(void)
 		rv = select(max_fd + 1, &rfds, NULL, NULL, &tv);
 		if (rv > 0) {
 			for (i = 0; i < num_fds; i++)
-				if (FD_ISSET(fds[i], &rfds) &&
-				    handle_events(fds[i]) == -1) {
+				if (FD_ISSET(fds[i], &rfds)) {
+					ret_t r;
+
+					r = handle_events(fds[i], NULL);
+					if (r == ret_continue)
+						continue;
+
+					ret = get_exit_status(r);
 					running = 0;
 					break;
 				}

--- a/yamui-tools.c
+++ b/yamui-tools.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Igor Zhbanov <igor.zhbanov@jolla.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <linux/input.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "yamui-tools.h"
+
+extern const char *app_name;
+
+/* ------------------------------------------------------------------------ */
+
+static void
+print_common(const char *format, va_list ap)
+{
+	printf("[%s] ", app_name);
+	vprintf(format, ap);
+}
+
+/* ------------------------------------------------------------------------ */
+
+/* Info printing with printf-style format and application name prefix. */
+void
+infof(const char *format, ...)
+{
+	va_list ap;
+	int old_errno = errno;
+
+	va_start(ap, format);
+	print_common(format, ap);
+	printf("\n");
+	va_end(ap);
+	errno = old_errno; /* Just in case. */
+}
+
+/* ------------------------------------------------------------------------ */
+
+/* perror() with printf-style format and application name prefix. */
+void
+errorf(const char *format, ...)
+{
+	va_list ap;
+	int old_errno = errno;
+
+	va_start(ap, format);
+	print_common(format, ap);
+	printf(": %s\n", strerror(old_errno));
+	va_end(ap);
+	errno = old_errno; /* Just in case. */
+}
+
+/* ------------------------------------------------------------------------ */
+
+/* Open all /dev/input/event* files. */
+int
+open_fds(int fds[], int *num, int max_num, device_filter_t device_filter)
+{
+	DIR *dir;
+	struct dirent *d;
+
+	if (!(dir = opendir(DEV_INPUT_DIR))) {
+		errorf("Can't open directory %s", DEV_INPUT_DIR);
+		return -1;
+	}
+
+	while ((d = readdir(dir))) {
+		char name[256];
+
+		if (strncmp(d->d_name, EVENT_PREFIX, strlen(EVENT_PREFIX)))
+			continue; /* Not /dev/input/event* file */
+
+		snprintf(name, sizeof(name), "%s/%s", DEV_INPUT_DIR,
+			 d->d_name);
+		debugf("Processing input ivents file %s", name);
+		if ((fds[*num] = open(name, O_RDONLY)) == -1) {
+			errorf("Can't open input device %s", name);
+			continue;
+		}
+
+		if (device_filter && device_filter(fds[*num], name) == -1) {
+			close(fds[*num]);
+			continue;
+		}
+
+		if (++*num >= max_num)
+			break;
+	}
+
+	closedir(dir);
+	if (!*num) {
+		infof("No suitable input events devices found.");
+		return -1;
+	}
+
+	return 0;
+}
+
+/* ------------------------------------------------------------------------ */
+
+void
+close_fds(int fds[], int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		close(fds[i]);
+}
+
+/* ------------------------------------------------------------------------ */
+
+/* Returns:
+ * ret_success	- Power key was pressed, terminate main loop.
+ * ret_continue	- Some other key was pressed or released, continue main loop.
+ * ret_failure	- Error happens, terminate the application. */
+ret_t
+handle_events(int fd, event_handler_t event_handler)
+{
+	size_t i;
+	ssize_t rv;
+	ret_t ret;
+	struct input_event buf[EVENTS_BUF_SIZE];
+
+	/* Read and ignore event data if OK. */
+	rv = read(fd, (void *)buf, sizeof(buf));
+	if (rv < 0) {
+		errorf("Error on read");
+		return ret_failure;
+	} else if (rv == 0) {
+		infof("Unexpected EOF on read");
+		return ret_failure;
+	} else if (rv % sizeof(struct input_event)) {
+		infof("Read incomplete input_event structure");
+		return ret_failure;
+	}
+
+	if (event_handler)
+		for (i = 0; i < rv / sizeof(struct input_event); i++)
+			if ((ret = event_handler(&buf[i])) != ret_continue)
+				return ret;
+
+	return ret_continue;
+}
+
+/* ------------------------------------------------------------------------ */
+
+/* Map functions return status to main() exit status. */
+int
+get_exit_status(ret_t r)
+{
+	return (r == ret_success) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/yamui-tools.h
+++ b/yamui-tools.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Igor Zhbanov <igor.zhbanov@jolla.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _YAMUI_TOOLS_H_
+#define _YAMUI_TOOLS_H_
+
+#include <stdio.h>
+#include <linux/input.h>
+
+#define UNUSED	__attribute__((unused))
+
+void infof(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+void errorf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
+
+#ifdef DEBUG
+
+#define debugf	infof
+
+#else /* !DEBUG */
+
+static void
+debugf(const char *format, ...) __attribute__ ((format (printf, 1, 2)))
+				UNUSED;
+
+static __inline__ void
+debugf(const char *format UNUSED, ...)
+{
+
+}
+
+#endif /* !DEBUG */
+
+#define DEV_INPUT_DIR	"/dev/input"
+#define EVENT_PREFIX	"event"
+#define EVENTS_BUF_SIZE	512 /* events */
+
+typedef int (*device_filter_t)(int fd, const char *name);
+int open_fds(int fds[], int *num, int max_num, device_filter_t device_filter);
+void close_fds(int fds[], int num);
+
+typedef enum {
+	ret_success,
+	ret_failure,
+	ret_continue
+} ret_t;
+
+int get_exit_status(ret_t r);
+
+typedef ret_t (*event_handler_t)(const struct input_event *ev);
+ret_t handle_events(int fd, event_handler_t event_handler);
+
+#endif /* _YAMUI_TOOLS_H_ */


### PR DESCRIPTION
Add yamui-powerkey tool to wait for power key events device-independently.
Update Makefile and spec-file.
Factor out common code to yamui-tools.c and yamui-tools.h.
Replace macro LOG_NAME by variable app_name.
Make open_fds() to accept filter argument.
Change return type of handle_events() to ret_t;
Remove EXIT_SUCCESS and EXIT_FAILURE defines (they are defined in stdlib.h).

Signed-off-by: Igor Zhbanov igor.zhbanov@jolla.com
