### PR TITLE
[yamuisplash] Cleanup after receiving SIGTERM. Fixes JB#54164

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#define _BSD_SOURCE	700
+#define _DEFAULT_SOURCE
 
 #include <stdio.h>
 #include <getopt.h>

--- a/main.c
+++ b/main.c
@@ -89,6 +89,8 @@ main(int argc, char *argv[])
 	int ret = 0;
 	int i = 0;
 
+	setlinebuf(stdout);
+
 	while (1) {
 		c = getopt_long(argc, argv, "a:i:p:s:t:h", options,
 				&option_index);

--- a/minui/resources.c
+++ b/minui/resources.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <png.h>
 #include <fcntl.h>

--- a/yamui-powerkey.c
+++ b/yamui-powerkey.c
@@ -22,7 +22,7 @@
  * limitations under the License.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _GNU_SOURCE
 
 #include <errno.h>

--- a/yamui-screensaverd.c
+++ b/yamui-screensaverd.c
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <errno.h>
 #include <stdio.h>

--- a/yamui-tools.c
+++ b/yamui-tools.c
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
It's important to call gr_exit() that will set KDMODE back to KD_TEXT on
exit. Stop waiting when interrupted by SIGTERM or SIGINT and go to
cleanup. select() and usleep() usage is converted to pselect().
pselect() monitors signalfd and unlike select() it doesn't change its
timeout argument.

Also use line buffering for stdout. This allows messages to appear in
journal in timely manner instead of blurping a bunch of them at exit time.

Use _DEFAULT_SOURCE instead of deprecated _BSD_SOURCE.
Avoids a compiler warning.