### PR TITLE
[graphics] Put the dummy drm init+exit step back in. JB#59812

### DIFF
--- a/minui/graphics.c
+++ b/minui/graphics.c
@@ -431,11 +431,19 @@ static int gr_init_fbdev(bool blank)
 
 static int gr_init_drm(bool blank)
 {
+	gr_backend = open_drm();
+
+	/* At least in Xperia 10: the first display open succeeds
+	 * without any trace of problems, but nothing is actually
+	 * drawn on screen - make sure we get past that...
+	 */
+	gr_backend->init(gr_backend, blank);
+	gr_backend->exit(gr_backend);
+
 	/* Assume that failures can happen due to there being
 	 * another process that is trying to release display
 	 * and allow some slack for that to finish.
 	 */
-	gr_backend = open_drm();
 	for (int failures = 0;;) {
 		gr_draw = gr_backend->init(gr_backend, blank);
 		if (gr_draw)

--- a/minui/graphics.c
+++ b/minui/graphics.c
@@ -490,11 +490,16 @@ gr_init(bool blank)
 void
 gr_exit(void)
 {
-	gr_backend->exit(gr_backend);
+	if (gr_backend) {
+		gr_backend->exit(gr_backend);
+		gr_backend = NULL;
+	}
 
-	ioctl(gr_vt_fd, KDSETMODE, (void *)KD_TEXT);
-	close(gr_vt_fd);
-	gr_vt_fd = -1;
+	if (gr_vt_fd != -1) {
+		ioctl(gr_vt_fd, KDSETMODE, (void *)KD_TEXT);
+		close(gr_vt_fd);
+		gr_vt_fd = -1;
+	}
 }
 
 /* ------------------------------------------------------------------------ */

--- a/yamui.c
+++ b/yamui.c
@@ -267,7 +267,7 @@ display_can_be_drawn(void)
  * ========================================================================= */
 
 /** Path to D-Bus SystemBus socket */
-# define SYSTEMBUS_SOCKET_PATH "/run/dbus/system_bus_socket"
+#define SYSTEMBUS_SOCKET_PATH "/run/dbus/system_bus_socket"
 
 static bool          systembus_socket_exists    = false;
 static GFileMonitor *systembus_socket_monitor   = NULL;
@@ -725,27 +725,27 @@ cleanup:
  * ========================================================================= */
 
 /** Well known dbus name of compositor service */
-# define COMPOSITOR_SERVICE                     "org.nemomobile.compositor"
-# define COMPOSITOR_PATH                        "/"
-# define COMPOSITOR_IFACE                       "org.nemomobile.compositor"
+#define COMPOSITOR_SERVICE                     "org.nemomobile.compositor"
+#define COMPOSITOR_PATH                        "/"
+#define COMPOSITOR_IFACE                       "org.nemomobile.compositor"
 
 /** Enabling/disabling display updates via compositor service */
-# define COMPOSITOR_SET_UPDATES_ENABLED         "setUpdatesEnabled"
+#define COMPOSITOR_SET_UPDATES_ENABLED         "setUpdatesEnabled"
 
 /** Query owner of topmost ui window */
-# define COMPOSITOR_GET_TOPMOST_WINDOW_PID	"privateTopmostWindowProcessId"
+#define COMPOSITOR_GET_TOPMOST_WINDOW_PID      "privateTopmostWindowProcessId"
 
 /** Change notification for owner of topmost ui window */
-# define COMPOSITOR_TOPMOST_WINDOW_PID_CHANGED  "privateTopmostWindowProcessIdChanged"
+#define COMPOSITOR_TOPMOST_WINDOW_PID_CHANGED  "privateTopmostWindowProcessIdChanged"
 
 /** Query requirements of this compositor process */
-# define COMPOSITOR_GET_SETUP_ACTIONS           "privateGetSetupActions"
+#define COMPOSITOR_GET_SETUP_ACTIONS           "privateGetSetupActions"
 
 /** Setup actions supported by mce */
-# define COMPOSITOR_ACTION_NONE                 0
-# define COMPOSITOR_ACTION_STOP_HWC             (1<<0)
-# define COMPOSITOR_ACTION_START_HWC            (1<<1)
-# define COMPOSITOR_ACTION_RESTART_HWC          (1<<2)
+#define COMPOSITOR_ACTION_NONE                 0
+#define COMPOSITOR_ACTION_STOP_HWC             (1<<0)
+#define COMPOSITOR_ACTION_START_HWC            (1<<1)
+#define COMPOSITOR_ACTION_RESTART_HWC          (1<<2)
 
 /** Introspect XML - needed for setting up glib based dbus service */
 static const char introspect_xml[] = ""
@@ -1157,10 +1157,10 @@ cleanup:
 static void
 app_flush_images(void)
 {
-    while (app_image_count > 0) {
-	gchar *filepath = app_images[--app_image_count];
-	g_free(filepath);
-    }
+	while (app_image_count > 0) {
+		gchar *filepath = app_images[--app_image_count];
+		g_free(filepath);
+	}
 }
 
 /** Hook for redrawing ui content after display unblank
@@ -1548,11 +1548,10 @@ cleanup:
 	 * during compositor handover).
 	 */
 	if (debugging) {
-	    display_release();
-	    app_flush_images();
-	    compositor_cancel_connect();
-	    systembus_quit_socket_monitor();
-	    compositor_quit();
+		display_release();
+		app_flush_images();
+		systembus_quit_socket_monitor();
+		compositor_quit();
 	}
 
 	log_debug("exit");

--- a/yamui.c
+++ b/yamui.c
@@ -184,7 +184,7 @@ display_acquire(void)
 		display_acquired = true;
 		if (gr_init(true) == -1) {
 			log_err("gr_init() failed");
-			display_released = true;
+			display_release();
 			mainloop_stop();
 		}
 		else {
@@ -201,7 +201,7 @@ display_acquire(void)
 static void
 display_release(void)
 {
-	if (display_acquired && !display_released) {
+	if (!display_released) {
 		display_released = true;
 		freeLogo();
 		gr_exit();


### PR DESCRIPTION
[yamui] Normalize indentation

Should be: Indent by 8 and use leading tabs.

[yamui] Call gr_exit() even if gr_init() fails

Failing gr_init() call can leave dynamic resources behind
and these are not released unless gr_exit() is called.

Ensure that yamui does not skip gr_exit() on gr_init() failure

[graphics] Fix potential null deref in gr_exit()

For example partially successful gr_init() call can call gr_exit()
before gr_backend has been set to non-null value.

Check that gr_backend has non-null value before use.

While at it, check also that gr_vt_fd has actually been opened.

[graphics] Put the dummy drm init+exit step back in. JB#59812

In Xperia 10 yamui works when tested after bootup, but shows blank
screen when used for bootup splash screen (as the real intent is).

So, apparently that dummy drm init+exit that got removed in refactoring
is after all needed for some devices and needs to be put back in.
