### PR TITLE
[yamui] Always terminate old instance via unix socket

### DIFF
--- a/minui/graphics.c
+++ b/minui/graphics.c
@@ -104,10 +104,12 @@ text_blend(unsigned char *src_p, int src_row_bytes, unsigned char *dst_p,
 				px++;
 			} else if (a > 0) {
 				int b = 255 - a;
-				*px++ = (*px * b + gr_current_r * a) / 255;
-				*px++ = (*px * b + gr_current_g * a) / 255;
-				*px++ = (*px * b + gr_current_b * a) / 255;
-				px++;
+				*px = (*px * b + gr_current_r * a) / 255;
+				px += 1;
+				*px = (*px * b + gr_current_g * a) / 255;
+				px += 1;
+				*px = (*px * b + gr_current_b * a) / 255;
+				px += 2;
 			} else {
 				px += 4;
 			}


### PR DESCRIPTION
When D-Bus is available, yamui uses compositor name ownership and
permission to draw ipc from mce for orderly handoff of display
ownership. When D-Bus is not available, custom unix server socket is
used for the same purpose until D-Bus becomes available.

However, there is a timing hazard in cases where one yamui instance is
launched immediately before dbus daemon and another one immediately
after: the second instance might gain D-Bus name and false positive
permission to draw while the 1st one is still holding the display.

Change yamui behavior so that regardless of D-Bus availablity: make an
attempt to terminate previous instance via unix socket, then take over
and listen to unix socket until permission to draw is received from mce
over D-Bus.

Also treat absence of connectable unix server socket as success when
requesting termination of previous yamui instance.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>